### PR TITLE
Add Check on date

### DIFF
--- a/NationalRegisterNumber/NationalRegisterNumberGenerator.cs
+++ b/NationalRegisterNumber/NationalRegisterNumberGenerator.cs
@@ -1,4 +1,6 @@
-﻿namespace NationalRegisterNumber;
+using System.Globalization;
+
+namespace NationalRegisterNumber;
 
 public static class NationalRegisterNumberGenerator
 {
@@ -27,21 +29,31 @@ public static class NationalRegisterNumberGenerator
         if (string.IsNullOrEmpty(numbersOnly) || numbersOnly.Length != 11)
             return false;
 
+        // check date
+
+        if (!DateTime.TryParseExact(
+         numbersOnly[..6],
+         "yyMMdd",
+         CultureInfo.InvariantCulture,
+         DateTimeStyles.None,
+         out var d))
+            return false;
+
         // Check control number
-        if (!long.TryParse(nationalRegisterNumber[..9], out var dividend))
+        if (!long.TryParse(numbersOnly[..9], out var dividend))
             return false;
 
         var remainder = dividend % Divisor;
         var controlNumber = Divisor - remainder;
 
-        if (!long.TryParse(nationalRegisterNumber[9..], out var actualControlNumber))
+        if (!long.TryParse(numbersOnly[9..], out var actualControlNumber))
             return false;
 
         // Born before 2000/01/01
         if (controlNumber == actualControlNumber)
             return true;
 
-        if (!long.TryParse($"2{nationalRegisterNumber[..9]}", out dividend))
+        if (!long.TryParse($"2{numbersOnly[..9]}", out dividend))
             return false;
 
         remainder = dividend % Divisor;

--- a/NationalRegisterNumberTests/NationalRegisterNumberTests.cs
+++ b/NationalRegisterNumberTests/NationalRegisterNumberTests.cs
@@ -18,6 +18,8 @@ public class NationalRegisterNumberTests
     }
 
     [TestCase("12345678910")]
+    [TestCase("12345621748")]
+    [TestCase("12345621777")]
     [TestCase("Test")]
     [TestCase("00000000000")]
     [TestCase("99999999999")]


### PR DESCRIPTION
I have added an extra check on the date:

Below tests are actually invalid although the control number is correct

12345621748
12345621777

123456 is not a date.

Make use of your sanitized numbersonly variable but you have to check if this is expected behavior